### PR TITLE
Handle integers in VG size checks, avoid panic on unexpected input

### DIFF
--- a/daemon/client/checks/common.go
+++ b/daemon/client/checks/common.go
@@ -135,8 +135,6 @@ func isLvsSizeOk(stdOut string, okSize int) bool {
 	// Examples
 	// 42.10  8.86   docker-pool
 	// 13.63  8.93   lv_fast_registry_pool
-	num := regexp.MustCompile("(\\d+\\.\\d+)")
-
 	checksOk := 0
 	for _, nr := range num.FindAllString(stdOut, -1) {
 		i, err := strconv.ParseFloat(nr, 64)

--- a/daemon/client/checks/common.go
+++ b/daemon/client/checks/common.go
@@ -22,7 +22,7 @@ const (
 	kubernetesIP = "172.30.0.1"
 )
 
-var num = regexp.MustCompile("(\\d+\\.\\d+)")
+var num = regexp.MustCompile(`\d+(?:\.\d+)?`)
 
 func CheckExternalSystem(url string) (error) {
 	if err := checkHttp(url); err != nil {

--- a/daemon/client/checks/common.go
+++ b/daemon/client/checks/common.go
@@ -92,6 +92,9 @@ func getEndpoint(slow bool) string {
 	}
 }
 
+// isVgSizeOk returns true if vgs output in stdOut indicates that the volume
+// group free space is equal or above the percentage treshold okSize, which is
+// expected to be in the range [0, 100].
 func isVgSizeOk(stdOut string, okSize int) bool {
 	// Example
 	// 5.37 26.84 vg_fast_registry

--- a/daemon/client/checks/common.go
+++ b/daemon/client/checks/common.go
@@ -22,6 +22,7 @@ const (
 	kubernetesIP = "172.30.0.1"
 )
 
+var num = regexp.MustCompile("(\\d+\\.\\d+)")
 
 func CheckExternalSystem(url string) (error) {
 	if err := checkHttp(url); err != nil {
@@ -99,7 +100,6 @@ func isVgSizeOk(stdOut string, okSize int) bool {
 	// Example
 	// 5.37 26.84 vg_fast_registry
 	// 5.37 26.84 vg_slow
-	num := regexp.MustCompile("(\\d+\\.\\d+)")
 	nums := num.FindAllString(stdOut, -1)
 
 	free, err := strconv.ParseFloat(nums[0], 64)

--- a/daemon/client/checks/common.go
+++ b/daemon/client/checks/common.go
@@ -112,7 +112,7 @@ func isVgSizeOk(stdOut string, okSize int) bool {
 
 	// calculate usage
 	if (100 / size * free < float64(okSize)) {
-		msg := fmt.Sprintf("VG free size is below treshold. Size: %v, free: %v, treshold: %v %", size, free, okSize)
+		msg := fmt.Sprintf("VG free size is below treshold. Size: %v, free: %v, treshold: %v %%", size, free, okSize)
 		log.Println(msg)
 		return false
 	}

--- a/daemon/client/checks/common.go
+++ b/daemon/client/checks/common.go
@@ -100,7 +100,12 @@ func isVgSizeOk(stdOut string, okSize int) bool {
 	// Example
 	// 5.37 26.84 vg_fast_registry
 	// 5.37 26.84 vg_slow
-	nums := num.FindAllString(stdOut, -1)
+	nums := num.FindAllString(stdOut, 2)
+
+	if len(nums) != 2 {
+		log.Println("Unable to parse vgs output:", stdOut)
+		return false
+	}
 
 	free, err := strconv.ParseFloat(nums[0], 64)
 	if (err != nil) {

--- a/daemon/client/checks/common.go
+++ b/daemon/client/checks/common.go
@@ -128,6 +128,9 @@ func isVgSizeOk(stdOut string, okSize int) bool {
 	return true
 }
 
+// isLvsSizeOk returns true if lvs output in stdOut indicates that the logical
+// volume percentage full for data and metadata are both below the threshold
+// okSize, which is expected to be in the range [0, 100].
 func isLvsSizeOk(stdOut string, okSize int) bool {
 	// Examples
 	// 42.10  8.86   docker-pool

--- a/daemon/client/checks/common_test.go
+++ b/daemon/client/checks/common_test.go
@@ -21,6 +21,8 @@ func TestIsVgSizeOk(t *testing.T) {
 		{"invalid input", 99, false},
 		{"5.37 26.84 vg_slow", 5, true},
 		{"5.37 26.84 vg_slow", 25, false},
+		{"      0 511.03 fedora", 10, false},
+		{"\t25\t250 test", 10, true},
 	}
 	for _, tt := range tests {
 		if got := isVgSizeOk(tt.line, tt.okSize); got != tt.want {

--- a/daemon/client/checks/common_test.go
+++ b/daemon/client/checks/common_test.go
@@ -1,0 +1,29 @@
+package checks
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+)
+
+func init() {
+	// Omit standard log output when running tests to allow one to focus on
+	// actual test results.
+	log.SetOutput(ioutil.Discard)
+}
+
+func TestIsVgSizeOk(t *testing.T) {
+	tests := []struct {
+		line   string
+		okSize int
+		want   bool
+	}{
+		{"5.37 26.84 vg_slow", 5, true},
+		{"5.37 26.84 vg_slow", 25, false},
+	}
+	for _, tt := range tests {
+		if got := isVgSizeOk(tt.line, tt.okSize); got != tt.want {
+			t.Errorf("isVgSizeOk(%q, %v) = %v, want %v", tt.line, tt.okSize, got, tt.want)
+		}
+	}
+}

--- a/daemon/client/checks/common_test.go
+++ b/daemon/client/checks/common_test.go
@@ -18,6 +18,7 @@ func TestIsVgSizeOk(t *testing.T) {
 		okSize int
 		want   bool
 	}{
+		{"invalid input", 99, false},
 		{"5.37 26.84 vg_slow", 5, true},
 		{"5.37 26.84 vg_slow", 25, false},
 	}


### PR DESCRIPTION
I observed that `vgs` and `lvs` might return integers.
This PR changes the output parsing logic to handle either ints or floats, and avoids accessing out of range slice indices (that causes a runtime panic).

Also added a few unit tests for `isVgSizeOk` to demonstrate/test the functionality.