### PR TITLE
ignore not schedulabled hosts

### DIFF
--- a/daemon/client/checks/openshift.go
+++ b/daemon/client/checks/openshift.go
@@ -35,7 +35,7 @@ func CheckMasterApis(urls string) (error) {
 func CheckOcGetNodes() (error) {
 	log.Println("Checking oc get nodes output")
 
-	out, err := exec.Command("bash", "-c", "oc get nodes --show-labels | grep -v monitoring=false").Output()
+	out, err := exec.Command("bash", "-c", "oc get nodes --show-labels | grep -v monitoring=false | grep -v SchedulingDisabled").Output()
 	if err != nil {
 		msg := "Could not parse oc get nodes output: " + err.Error()
 		log.Println(msg)


### PR DESCRIPTION
Scheduling disabled Hosts sollten wir ignorieren