### PR TITLE
Cleaner checks for kube configs.

### DIFF
--- a/daemon/client/handlers/major.go
+++ b/daemon/client/handlers/major.go
@@ -26,12 +26,17 @@ func HandleMajorChecks(daemonType string, w http.ResponseWriter, r *http.Request
 
 	if daemonType == "MASTER" || daemonType == "NODE" {
 		certPaths := os.Getenv("CHECK_CERTIFICATE_PATHS")
+		kubePaths := os.Getenv("CHECK_CERTIFICATE_KUBE_PATHS")
 
-		if len(certPaths) == 0 {
-			log.Fatal("env variables 'CHECK_CERTIFICATE_PATHS' must be specified")
+		if len(certPaths) == 0 || len(kubePaths) == 0 {
+			log.Fatal("env variables 'CHECK_CERTIFICATE_PATHS', 'CHECK_CERTIFICATE_KUBE_PATHS' must be specified")
 		}
 
 		if err := checks.CheckFileSslCertificates(strings.Split(certPaths, ","), 30); err != nil {
+			errors = append(errors, err.Error())
+		}
+
+		if err := checks.CheckKubeSslCertificates(strings.Split(kubePaths, ","), 30); err != nil {
 			errors = append(errors, err.Error())
 		}
 	}

--- a/daemon/client/handlers/minor.go
+++ b/daemon/client/handlers/minor.go
@@ -23,12 +23,17 @@ func HandleMinorChecks(daemonType string, w http.ResponseWriter, r *http.Request
 
 	if daemonType == "MASTER" || daemonType == "NODE" {
 		certPaths := os.Getenv("CHECK_CERTIFICATE_PATHS")
+		kubePaths := os.Getenv("CHECK_CERTIFICATE_KUBE_PATHS")
 
-		if len(certPaths) == 0 {
-			log.Fatal("env variables 'CHECK_CERTIFICATE_PATHS' must be specified")
+		if len(certPaths) == 0 || len(kubePaths) == 0 {
+			log.Fatal("env variables 'CHECK_CERTIFICATE_PATHS', 'CHECK_CERTIFICATE_KUBE_PATHS' must be specified")
 		}
 
 		if err := checks.CheckFileSslCertificates(strings.Split(certPaths, ","), 80); err != nil {
+			errors = append(errors, err.Error())
+		}
+
+		if err := checks.CheckKubeSslCertificates(strings.Split(kubePaths, ","), 80); err != nil {
 			errors = append(errors, err.Error())
 		}
 	}


### PR DESCRIPTION
Paths or files can be passed as array of strings to check functions so that all known paths and config files can be checked.

certs:
  master:
    - /etc/origin/master/ <--- path (all .crt files inside)
    - /etc/etcd/ <--- path (all .crt files inside)
  node:
    - /etc/origin/node/ <--- path (all .crt files inside)
  urls:
    - https://master.domain.org:8443
    - https://check.domain.org
  kube:
    - /etc/origin/node/ <--- path (all .kubeconfig files inside)
    - /root/.kube/config <--- file
    - /etc/origin/master/ <--- path (all .kubeconfig files inside)