### PR TITLE
Restart count of 4 seems to be normal in our current environment with…

### DIFF
--- a/daemon/client/checks/openshift.go
+++ b/daemon/client/checks/openshift.go
@@ -330,8 +330,8 @@ func CheckLoggingRestartsCount() error {
 	for _, l := range strings.Split(string(out), "\n") {
 		if !strings.HasPrefix(l, "RESTARTS") && len(strings.TrimSpace(l)) > 0 {
 			cnt, _ := strconv.Atoi(l)
-			if cnt > 2 {
-				msg = "A logging-container has restart count bigger than 2 - " + strconv.Itoa(cnt)
+			if cnt > 7 {
+				msg = "A logging-container has restart count bigger than 7 - " + strconv.Itoa(cnt)
 				isOk = false
 			}
 		}


### PR DESCRIPTION
… OpenShift 3.9 during node upgrades. If it get's over 7, we should have a look at it.